### PR TITLE
Fix cross_validation script crash

### DIFF
--- a/code/cross_validation.py
+++ b/code/cross_validation.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3.7
 import collections
 import operator
 import os


### PR DESCRIPTION
Fix the crash when running this script by forcing it to be run with
the 3.7 python interpreter.

This is necessary as some of the third-party libraries are not yet
compatible with python 3.8.